### PR TITLE
stack compute order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.2.0",
+  "version": "3.1.2",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -20,7 +20,6 @@ export function wrapObjectWithError(err, stacktraceErr, extraContext) {
 	else {
 		errOut = stacktraceErr || new Error();
 		errOut.autoTraceIgnore = true;
-		errOut = removeAutoTraceFromErrorStack(errOut);
 		try {
 			if (typeof err === "string"){
 				errOut.message = err;
@@ -33,6 +32,7 @@ export function wrapObjectWithError(err, stacktraceErr, extraContext) {
 			console.warn('auto-trace: You are trying to throw something that cannot be stringified', ex);
 			errOut.message = err;
 		}
+		errOut = removeAutoTraceFromErrorStack(errOut);
 	}
 
 	return appendExtraContext(errOut, extraContext);


### PR DESCRIPTION
When `err.stack` is accessed before `err.message` is set, the stack property will be computed without the err.message string. This fix sets the message before editing the stack.