### PR TITLE
Feature/attach original exception object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.2.0",
+  "version": "3.1.3",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -25,6 +25,7 @@ export function wrapObjectWithError(err, stacktraceErr, extraContext) {
 				errOut.message = err;
 			}
 			else {
+				errOut.originalErrorObject = err;
 				errOut.message = JSON.stringify(err);
 			}
 		}

--- a/src/auto-trace.helper.spec.js
+++ b/src/auto-trace.helper.spec.js
@@ -15,10 +15,18 @@ describe('auto-trace.js', () => {
 			//Should not contain wrapObjectWithError in stack trace
 			expect(err.stack.indexOf('wrapObjectWithError')).toEqual(-1);
 		});
-		it('should wraps non-errors in errors', () => {
+		it('should wrap non-errors in errors', () => {
 			const err = wrapObjectWithError('non-error');
 			expect(err).toEqual(jasmine.any(Error));
 			expect(err.message).toEqual('non-error');
+			expect(err.autoTraceIgnore).toEqual(true);
+			expect(err.stack.indexOf('wrapObjectWithError')).toEqual(-1);
+		});
+		it('should wrap non-errors objects in errors', () => {
+			const err = wrapObjectWithError({test: 'testing'});
+			expect(err).toEqual(jasmine.any(Error));
+			expect(err.message).toEqual(JSON.stringify({test: 'testing'}));
+			expect(err.originalErrorObject).toEqual({test: 'testing'});
 			expect(err.autoTraceIgnore).toEqual(true);
 			expect(err.stack.indexOf('wrapObjectWithError')).toEqual(-1);
 		});


### PR DESCRIPTION
Attach the original object to the error so that it can be accessed through `originalErrorObject`