### PR TITLE
Fix asyncStacktrace to return callback's return value.

### DIFF
--- a/src/auto-trace.js
+++ b/src/auto-trace.js
@@ -33,7 +33,7 @@ export function asyncStacktrace(callback = ()=>{}, extraContext) {
 	return (rawError) => {
 		const middlewareErr = executeSyncMiddleware(syncMiddlewareErrFunctions, rawError);
 		const errOut = wrapObjectWithError(middlewareErr, asyncStacktraceErr, extraContext)
-		callback(errOut);
+		return callback(errOut);
 	};
 }
 

--- a/src/auto-trace.spec.js
+++ b/src/auto-trace.spec.js
@@ -141,6 +141,17 @@ describe('auto-trace.js', () => {
 			customError.customProperty = true;
 			errCallback(customError);
 		});
+		it('should return the value returned by the callback', () => {
+			var expectedResult;
+			var errCallback = autoTrace.asyncStacktrace(err => {
+				expectedResult = err;
+				return err;
+			});
+			var customError = new Error('Custom message');
+			customError.customProperty = true;
+			const actualResult = errCallback(customError);
+			expect(actualResult).toBe(expectedResult);
+		});
 	});
 
 	describe('catchAsyncStacktrace', () => {


### PR DESCRIPTION
This allows you to return something from your `asyncStacktrace` call and have it work. For example:

```js
Observable
.throw('Something to ignore')
.catch(asyncStacktrace(err => {
  return 'A thing to return'
}))
.tap(val => console.log(val))

// Logs 'A thing to return'
```

Without this code change, what would be logged to the console is `undefined`