### PR TITLE
Combine sync and async stacktraces together

### DIFF
--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -13,10 +13,11 @@ export function wrapObjectWithError(err, asyncErr, extraContext) {
 	}
 	else if (err instanceof Error){
 		errOut = err;
-		const  extraStacktrace = asyncErr ? asyncErr.stack.replace('Error\n', '\nauto-trace Async stacktrace:\n') : '';
+		const extraStacktrace = asyncErr ? asyncErr.stack.replace('Error\n', '\nauto-trace Async stacktrace:\n') : '';
 		const extraFrames = extraStacktrace.split('\n');
-		/* I started to use Array.prototype.findIndex, but realized it isn't supported in IE11 and didn't want to require
-		 * everyone using auto-trace to polyfill it. So this is the poor man's impl.
+		/* We want to alter the stacktrace so that the human reading it can distinguish where the sync stacktrace ends and the
+		 * async stacktrace begins. I started implementation with Array.prototype.findIndex, but realized it isn't supported in IE11
+		 * and didn't want to require everyone using auto-trace to polyfill it. So this is the poor man's impl.
 		 */
 		for (let i=0; i<extraFrames.length; i++) {
 			if (extraFrames[i].indexOf('at') >= 0) {

--- a/src/auto-trace.helper.spec.js
+++ b/src/auto-trace.helper.spec.js
@@ -48,11 +48,15 @@ describe('auto-trace.js', () => {
 		});
 		it('should return error with message from first param and stacktrace of second param', () => {
 			const err = new Error('original error message');
-			const stacktraceErr = new Error('Stacktrace error message');
-			const result = wrapObjectWithError(err, stacktraceErr);
+			const asyncErr = new Error('Stacktrace error message');
+			const result = wrapObjectWithError(err, asyncErr);
 			expect(result).toEqual(jasmine.any(Error));
 			expect(result.message).toEqual('original error message');
-			expect(result.stack).toEqual(stacktraceErr.stack);
+
+			// It should have the stacktraces from both the err and the asyncErr
+			expect(result.stack.indexOf(asyncErr.stack)).toBeGreaterThan(-1);
+			expect(result.stack.indexOf(err.stack)).toBeGreaterThan(-1);
+
 			expect(result.autoTraceIgnore).toEqual(true);
 			expect(err.stack.indexOf('wrapObjectWithError')).toEqual(-1);
 		});


### PR DESCRIPTION
See https://sentry.canopytax.com/canopy/workflow-ui/issues/32556/ for an example of what this looks like in Sentry. And see screenshot below for what it looks like in browser console.

![screen shot 2017-03-22 at 1 49 53 pm](https://cloud.githubusercontent.com/assets/5524384/24217735/73710536-0f06-11e7-9731-76a0b8b3ad6f.png)
