### PR TITLE
Replace of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -13,21 +13,23 @@ export function wrapObjectWithError(err, asyncErr, extraContext) {
 	}
 	else if (err instanceof Error){
 		errOut = err;
-		const extraStacktrace = asyncErr ? asyncErr.stack.replace('Error\n', '\nauto-trace Async stacktrace:\n') : '';
-		const extraFrames = extraStacktrace.split('\n');
-		/* We want to alter the stacktrace so that the human reading it can distinguish where the sync stacktrace ends and the
-		 * async stacktrace begins. I started implementation with Array.prototype.findIndex, but realized it isn't supported in IE11
-		 * and didn't want to require everyone using auto-trace to polyfill it. So this is the poor man's impl.
-		 */
-		for (let i=0; i<extraFrames.length; i++) {
-			if (extraFrames[i].indexOf('at') >= 0) {
-				extraFrames[i] = '  at AUTO TRACE ASYNC: ' + extraFrames[i];
-				// Only do this one time
-				break;
+		if(asyncErr && typeof asyncErr.stack === "string"){
+			const extraStacktrace = asyncErr.stack.replace('Error\n', '\nauto-trace Async stacktrace:\n');
+			const extraFrames = extraStacktrace.split('\n');
+			/* We want to alter the stacktrace so that the human reading it can distinguish where the sync stacktrace ends and the
+			 * async stacktrace begins. I started implementation with Array.prototype.findIndex, but realized it isn't supported in IE11
+			 * and didn't want to require everyone using auto-trace to polyfill it. So this is the poor man's impl.
+			 */
+			for (let i=0; i<extraFrames.length; i++) {
+				if (extraFrames[i].indexOf('at') >= 0) {
+					extraFrames[i] = '  at AUTO TRACE ASYNC: ' + extraFrames[i];
+					// Only do this one time
+					break;
+				}
 			}
+			const  originalFrames = extraStacktrace.split('\n');
+			errOut.stack = originalFrames.slice(0, 25).join('\n') + extraFrames.slice(0, 25).join('\n');
 		}
-		const  originalFrames = extraStacktrace.split('\n');
-		errOut.stack = originalFrames.slice(0, 25).join('\n') + extraFrames.slice(0, 25).join('\n');
 		errOut.autoTraceIgnore = true;
 		errOut = removeAutoTraceFromErrorStack(errOut);
 	}


### PR DESCRIPTION
In IE / Edge there are times when the `Error.stack` property is undefined.
https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript

This makes a check to ensure that stack is a string before calling replace. This fixes the `replace of undefined` error: #https://sentry.canopytax.com/canopy/front-end-prod/issues/73851/

Haven't been able to reproduce the times when Error.stack is undefined, but from the error message this is clearly what was happening. 