### PR TITLE
Stacking problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -20,6 +20,7 @@ export function wrapObjectWithError(err, asyncErr, extraContext) {
 			errOut.stack = asyncFrames.slice(0, 25).join('\n') + syncFrames.slice(0, 25).join('\n');
 		}
 		errOut.autoTraceIgnore = true;
+		errOut = addErrorMessageToStack(errOut);
 	}
 	else {
 		errOut = asyncErr || createError(2);
@@ -37,6 +38,7 @@ export function wrapObjectWithError(err, asyncErr, extraContext) {
 			console.warn('auto-trace: You are trying to throw something that cannot be stringified', ex);
 			errOut.message = err;
 		}
+		errOut = addErrorMessageToStack(errOut);
 	}
 
 	return appendExtraContext(errOut, extraContext);
@@ -85,7 +87,7 @@ export function createError(framesToRemove = 1){
  * @param  {Error} err
  * @return {Error}
  */
-export function addErrorMessageToStack(err){
+function addErrorMessageToStack(err){
 	if(err instanceof Error && typeof err.stack === "string"){
 		if (err.message) {
 			/* In NodeJS, `throw err` does not print out the err.message, but instead only prints out the

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -80,7 +80,7 @@ export function appendExtraContext(error, extraContext){
  */
 export function removeAutoTraceFromErrorStack(err){
 	if(err instanceof Error && typeof err.stack === "string"){
-		err.stack = err.stack.replace(/\n.*(?:yncStacktrace|wrapObjectWithError) ?\(.*/g,'');
+		err.stack = err.stack.replace(/\n.*(?:yncStacktrace|wrapObjectWithError) ?\(.*auto-trace.*/g,'');
 		if (err.message) {
 			/* In NodeJS, `throw err` does not print out the err.message, but instead only prints out the
 			 * err.stack. Since auto-trace does fancy manipulation of which stack an error has, and what it

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -73,12 +73,16 @@ export function appendExtraContext(error, extraContext){
 	return errOut
 }
 
-export function createError(framesToRemove = 1){
+//This function creates an error and by default removes two frames from the error stack (to remove this method, and the caller, which will be a function inside auto-trace)
+//Optionaly extraframesToRemove can be specified to remove more frames if the stack trace will contain more auto-trace refrences.
+export function createError(extraframesToRemove = 1){
 	const error = new Error();
 	//We remove an extra frame since this function will create a frame as well
 	const newStack = error.stack.split('\n');
-	newStack.splice(1,framesToRemove+1);
-	error.stack = newStack.join('\n');
+	if (newStack.length > extraframesToRemove+1) {
+		newStack.splice(1,extraframesToRemove+1);
+		error.stack = newStack.join('\n');
+	}
 	return error;
 }
 

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -80,7 +80,7 @@ export function appendExtraContext(error, extraContext){
  */
 export function removeAutoTraceFromErrorStack(err){
 	if(err instanceof Error && typeof err.stack === "string"){
-		err.stack = err.stack.replace(/\n.*(?:yncStacktrace|wrapObjectWithError) ?\(.*auto-trace.*/g,'');
+		err.stack = err.stack.replace(/\n.*(yncStacktrace|wrapObjectWithError|\(.*auto-trace).*/g,'');
 		if (err.message) {
 			/* In NodeJS, `throw err` does not print out the err.message, but instead only prints out the
 			 * err.stack. Since auto-trace does fancy manipulation of which stack an error has, and what it

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -14,9 +14,9 @@ export function wrapObjectWithError(err, asyncErr, extraContext) {
 	else if (err instanceof Error){
 		errOut = err;
 		if(asyncErr && typeof asyncErr.stack === "string"){
+			const asyncFrames = asyncErr.stack.split('\n');
 			const syncStacktrace = '\n  at AUTO TRACE SYNC: ' + removeAutoTraceFromErrorStack(err).stack;
 			const syncFrames = syncStacktrace.split('\n');
-			const asyncFrames = asyncErr.stack.split('\n');
 			errOut.stack = asyncFrames.slice(0, 25).join('\n') + syncFrames.slice(0, 25).join('\n');
 		}
 		errOut.autoTraceIgnore = true;

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -17,6 +17,7 @@ export function wrapObjectWithError(err, asyncErr, extraContext) {
 			const asyncFrames = asyncErr.stack.split('\n');
 			const syncStacktrace = '\n  at AUTO TRACE SYNC: ' + err.stack;
 			const syncFrames = syncStacktrace.split('\n');
+			//keep first 25 frames of asyncStacktrace, followed by 25 frames of syncStacktrace
 			errOut.stack = asyncFrames.slice(0, 25).join('\n') + syncFrames.slice(0, 25).join('\n');
 		}
 		errOut.autoTraceIgnore = true;

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -75,13 +75,14 @@ export function appendExtraContext(error, extraContext){
 }
 
 //This function creates an error and by default removes two frames from the error stack (to remove this method, and the caller, which will be a function inside auto-trace)
-//Optionaly extraframesToRemove can be specified to remove more frames if the stack trace will contain more auto-trace refrences.
-export function createError(extraframesToRemove = 1){
+//Optionally extraFramesToRemove can be specified to remove more frames if the stack trace will contain more auto-trace refrences.
+export function createError(extraFramesToRemove = 1){
 	const error = new Error();
 	//We remove an extra frame since this function will create a frame as well
 	const newStack = error.stack.split('\n');
-	if (newStack.length > extraframesToRemove+1) {
-		newStack.splice(1,extraframesToRemove+1);
+	if (newStack.length > extraFramesToRemove+1) {
+		//Starts on line 1 since the 0th line of the stacktrace is the error message (which we don't want to remove)
+		newStack.splice(1, extraFramesToRemove+1);
 		error.stack = newStack.join('\n');
 	}
 	return error;

--- a/src/auto-trace.helper.spec.js
+++ b/src/auto-trace.helper.spec.js
@@ -1,4 +1,4 @@
-import { wrapObjectWithError, appendExtraContext } from './auto-trace.helper.js';
+import { wrapObjectWithError, appendExtraContext, createError } from './auto-trace.helper.js';
 
 describe('auto-trace.js', () => {
 
@@ -106,5 +106,19 @@ describe('auto-trace.js', () => {
 			const extraContext = {userid: 23, moreInfo:'junk'};
 			expect(appendExtraContext(err, extraContext)).toEqual(Error(`Something went wrong! Extra Context: {"userid":23,"moreInfo":"junk"}`));
 		});
+	});
+	describe('createError', () => {
+		it('should create and error and remove 2 lines from stack', () => {
+			const err = createError();
+			expect(err.stack.split('\n').length).toEqual(9);
+		});	
+		it('should create and error and remove 4 lines from stack', () => {
+			const err = createError(3);
+			expect(err.stack.split('\n').length).toEqual(7);
+		});	
+		it('should not remove any frames if the frames to remove count is larger than the total number of frames', () => {
+			const err = createError(100);
+			expect(err.stack.split('\n').length).toEqual(11);
+		});	
 	});
 });

--- a/src/auto-trace.helper.spec.js
+++ b/src/auto-trace.helper.spec.js
@@ -63,12 +63,14 @@ describe('auto-trace.js', () => {
 		it('should store sync and async stack traces', () => {
 			const err = new Error('My sync error message will be preserved');
 			err.stack = `Error: My sync error message will be preserved
+  at wrapObjectWithError(./node_modules/auto-trace/lib/auto-trace.helper.js:23:0)
 	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at Array.forEach(<anonymous>)`;
 			const asyncErr = new Error('My async error message will live on in the stack');
 			asyncErr.stack = `Error: My async error message will live on in the stack
+	at wrapObjectWithError(./node_modules/auto-trace/lib/auto-trace.helper.js:23:0)
 	at catchAsyncStacktrace(./node_modules/auto-trace/lib/auto-trace.js:67:0)
 	at SigningModal._this.createOrGetSigningExperience(./src/signing-modal.component.js:110:4)
 	at createOrGetSigningExperience(./src/signing-modal.component.js:77:7)
@@ -79,6 +81,7 @@ describe('auto-trace.js', () => {
 	at createOrGetSigningExperience(./src/signing-modal.component.js:77:7)
 	at closeAll(../jspm_packages/npm/react-dom@15.5.4/lib/Transaction.js:153:15)
   at AUTO TRACE SYNC: Error: My sync error message will be preserved
+	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at Array.forEach(<anonymous>)`;
@@ -205,7 +208,7 @@ describe('auto-trace.js', () => {
   at fancyUpdateAnswer (../src/source-forms/questions/question.component.js:77:3)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
-		it('should remove self regardless of the file', () => {
+		it('should not remove the invoker call of catchAsyncStacktrace', () => {
 			//IE and Edge docs - https://msdn.microsoft.com/en-us/library/windows/apps/hh699850.aspx
 			const err = new Error('err');
 			err.stack = `Error: it broke
@@ -213,21 +216,12 @@ describe('auto-trace.js', () => {
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at dispatchEvent(../jspm_packages/npm/react-dom@15.5.4/lib/ReactErrorUtils.js:69:15)
-	at invokeGuardedCallback(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginUtils.js:85:20)
-	at executeDispatch(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginUtils.js:108:4)
-	at executeDispatchesInOrder(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginHub.js:43:21)
-	at executeDispatchesAndRelease(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginHub.js:54:9)
-	at Array.forEach(<anonymous>)
 	at forEach(../jspm_packages/npm/react-dom@15.5.4/lib/forEachAccumulated.js:24:8)`;
 			const expectedStack = `Error: it broke
+	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at dispatchEvent(../jspm_packages/npm/react-dom@15.5.4/lib/ReactErrorUtils.js:69:15)
-	at invokeGuardedCallback(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginUtils.js:85:20)
-	at executeDispatch(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginUtils.js:108:4)
-	at executeDispatchesInOrder(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginHub.js:43:21)
-	at executeDispatchesAndRelease(../jspm_packages/npm/react-dom@15.5.4/lib/EventPluginHub.js:54:9)
-	at Array.forEach(<anonymous>)
 	at forEach(../jspm_packages/npm/react-dom@15.5.4/lib/forEachAccumulated.js:24:8)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});

--- a/src/auto-trace.helper.spec.js
+++ b/src/auto-trace.helper.spec.js
@@ -61,13 +61,13 @@ describe('auto-trace.js', () => {
 			expect(err.stack.indexOf('wrapObjectWithError')).toEqual(-1);
 		});
 		it('should store sync and async stack traces', () => {
-			const err = new Error('My error message will be preserved');
+			const err = new Error('My sync error message will be preserved');
 			err.stack = `Error: My sync error message will be preserved
 	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at Array.forEach(<anonymous>)`;
-			const asyncErr = new Error('My error message will live on in the stack');
+			const asyncErr = new Error('My async error message will live on in the stack');
 			asyncErr.stack = `Error: My async error message will live on in the stack
 	at catchAsyncStacktrace(./node_modules/auto-trace/lib/auto-trace.js:67:0)
 	at SigningModal._this.createOrGetSigningExperience(./src/signing-modal.component.js:110:4)
@@ -83,7 +83,7 @@ describe('auto-trace.js', () => {
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at Array.forEach(<anonymous>)`;
 			expect(result.stack).toEqual(expectedStackTrace);
-			expect(result.message).toEqual(`My error message will be preserved`);
+			expect(result.message).toEqual(`My sync error message will be preserved`);
 		});
 	});
 

--- a/src/auto-trace.helper.spec.js
+++ b/src/auto-trace.helper.spec.js
@@ -49,6 +49,12 @@ describe('auto-trace.js', () => {
 		it('should return error with message from first param and stacktrace of second param', () => {
 			const err = new Error('original error message');
 			const asyncErr = new Error('Stacktrace error message');
+			err.stack = `Error:
+	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
+	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)`
+			asyncErr.stack = `Error:
+	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
+	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)`
 			const result = wrapObjectWithError(err, asyncErr);
 			expect(result).toEqual(jasmine.any(Error));
 			expect(result.message).toEqual('original error message');
@@ -63,15 +69,15 @@ describe('auto-trace.js', () => {
 		it('should store sync and async stack traces', () => {
 			const err = new Error('My sync error message will be preserved');
 			err.stack = `Error: My sync error message will be preserved
-  at wrapObjectWithError(./node_modules/auto-trace/lib/auto-trace.helper.js:23:0)
+  at wrapObjectWithError(./node_modules/trace/lib/trace.helper.js:23:0)
 	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at Array.forEach(<anonymous>)`;
 			const asyncErr = new Error('My async error message will live on in the stack');
 			asyncErr.stack = `Error: My async error message will live on in the stack
-	at wrapObjectWithError(./node_modules/auto-trace/lib/auto-trace.helper.js:23:0)
-	at catchAsyncStacktrace(./node_modules/auto-trace/lib/auto-trace.js:67:0)
+	at wrapObjectWithError(./node_modules/trace/lib/trace.helper.js:23:0)
+	at catchAsyncStacktrace(./node_modules/trace/lib/trace.js:67:0)
 	at SigningModal._this.createOrGetSigningExperience(./src/signing-modal.component.js:110:4)
 	at createOrGetSigningExperience(./src/signing-modal.component.js:77:7)
 	at closeAll(../jspm_packages/npm/react-dom@15.5.4/lib/Transaction.js:153:15)`
@@ -81,7 +87,6 @@ describe('auto-trace.js', () => {
 	at createOrGetSigningExperience(./src/signing-modal.component.js:77:7)
 	at closeAll(../jspm_packages/npm/react-dom@15.5.4/lib/Transaction.js:153:15)
   at AUTO TRACE SYNC: Error: My sync error message will be preserved
-	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at Array.forEach(<anonymous>)`;
@@ -111,50 +116,38 @@ describe('auto-trace.js', () => {
 		it('should replace instances of wrapObjectWithError and AsyncStacktrace', () => {
 			const err = new Error('err');
 			err.stack = `Error
-    at wrapObjectWithError (src/auto-trace.helper.js:21:29)
-    at AsyncStacktrace (src/auto-trace.helper.js:21:29)
-    at Object.<anonymous> (src/auto-trace.helper.spec.js:12:16)
-    at attemptSync (/Users/keith/dev/auto-trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
+    at wrapObjectWithError (src/trace.helper.js:21:29)
+    at AsyncStacktrace (src/trace.helper.js:21:29)
+    at Object.<anonymous> (src/trace.helper.spec.js:12:16)
+    at attemptSync (/Users/keith/dev/trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
     		const expectedStack = `Error: err
-    at Object.<anonymous> (src/auto-trace.helper.spec.js:12:16)
-    at attemptSync (/Users/keith/dev/auto-trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
+    at Object.<anonymous> (src/trace.helper.spec.js:12:16)
+    at attemptSync (/Users/keith/dev/trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
 		it('should work with node stacktrace', () => {
 			const err = new Error('err');
 			err.stack = `Error
-    at AsyncStacktrace (src/auto-trace.helper.js:21:29)
-    at Object.<anonymous> (src/auto-trace.helper.spec.js:12:16)
-    at attemptSync (/Users/keith/dev/auto-trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
+    at AsyncStacktrace (src/trace.helper.js:21:29)
+    at Object.<anonymous> (src/trace.helper.spec.js:12:16)
+    at attemptSync (/Users/keith/dev/trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
     		const expectedStack = `Error: err
-    at Object.<anonymous> (src/auto-trace.helper.spec.js:12:16)
-    at attemptSync (/Users/keith/dev/auto-trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
+    at Object.<anonymous> (src/trace.helper.spec.js:12:16)
+    at attemptSync (/Users/keith/dev/trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
 		it('should work with chrome stacktrace', () => {
 			const err = new Error('err');
 			err.stack = `Error: {"code":0,"message":"An unknown error occurred","status":500}
-  at asyncStacktrace(~/auto-trace/lib/auto-trace.js:46:27)
+  at asyncStacktrace(~/trace/lib/trace.js:46:27)
   at a(./angular/app/admin/sources/sources-settings.component.js:112:28)
   at fn(eval at compile (https://cdn.canopytax.com/sofe/workflow-ui/v5.1.0-1491-g6f60869/workflow-ui.js), <anonymous>:4:410)
   at g(~/angular/angular.min.js:126:127)
-  at this(~/angular/angular.min.js:276:194)
-  at $eval(~/angular/angular.min.js:145:347)
-  at $apply(~/angular/angular.min.js:146:51)
-  at apply(~/angular/angular.min.js:276:246)
-  at apply(../jspm_packages/npm/jquery@2.2.4/dist/jquery.js:4736:5)
-  at apply(../jspm_packages/npm/jquery@2.2.4/dist/jquery.js:4548:4)
   at apply(raven.js:379:28)`;
     		const expectedStack = `Error: {"code":0,"message":"An unknown error occurred","status":500}
   at a(./angular/app/admin/sources/sources-settings.component.js:112:28)
   at fn(eval at compile (https://cdn.canopytax.com/sofe/workflow-ui/v5.1.0-1491-g6f60869/workflow-ui.js), <anonymous>:4:410)
   at g(~/angular/angular.min.js:126:127)
-  at this(~/angular/angular.min.js:276:194)
-  at $eval(~/angular/angular.min.js:145:347)
-  at $apply(~/angular/angular.min.js:146:51)
-  at apply(~/angular/angular.min.js:276:246)
-  at apply(../jspm_packages/npm/jquery@2.2.4/dist/jquery.js:4736:5)
-  at apply(../jspm_packages/npm/jquery@2.2.4/dist/jquery.js:4548:4)
   at apply(raven.js:379:28)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
@@ -162,29 +155,17 @@ describe('auto-trace.js', () => {
 			//firefox stacktrace docs -  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack
 			const err = new Error('err');
 			err.stack = `Error: message
-  at asyncStacktrace(../jspm_packages/npm/auto-trace@2.2.0/lib/auto-trace.js:46:2)
+  at asyncStacktrace(../jspm_packages/npm/trace@2.2.0/lib/trace.js:46:2)
   at updateAnswer/<(../src/source-forms/answers/answer.actions.js:60:4)
   at createThunkMiddleware/</</<(../jspm_packages/npm/redux-thunk@2.1.0/lib/index.js:11:10)
   at func(../jspm_packages/npm/redux@3.5.2/lib/bindActionCreators.js:7:4)
   at apply(../jspm_packages/npm/lodash@4.13.1/lodash.js:413:4)
-  at f(../jspm_packages/npm/lodash@4.13.1/lodash.js:4836:8)
-  at fancyUpdateAnswer(../src/source-forms/questions/question.component.js:77:3)
-  at func(../src/source-forms/inputs/currency.component.js:75:3)
-  at ReactErrorUtils(../jspm_packages/npm/react@15.2.1/lib/ReactErrorUtils.js:26:11)
-  at executeDispatch(../jspm_packages/npm/react@15.2.1/lib/EventPluginUtils.js:89:4)
-  at EventPluginUtils(../jspm_packages/npm/react@15.2.1/lib/EventPluginUtils.js:112:4)
   at executeDispatchesAndRelease(../jspm_packages/npm/react@15.2.1/lib/EventPluginHub.js:44:4)`;
     		const expectedStack = `Error: message
   at updateAnswer/<(../src/source-forms/answers/answer.actions.js:60:4)
   at createThunkMiddleware/</</<(../jspm_packages/npm/redux-thunk@2.1.0/lib/index.js:11:10)
   at func(../jspm_packages/npm/redux@3.5.2/lib/bindActionCreators.js:7:4)
   at apply(../jspm_packages/npm/lodash@4.13.1/lodash.js:413:4)
-  at f(../jspm_packages/npm/lodash@4.13.1/lodash.js:4836:8)
-  at fancyUpdateAnswer(../src/source-forms/questions/question.component.js:77:3)
-  at func(../src/source-forms/inputs/currency.component.js:75:3)
-  at ReactErrorUtils(../jspm_packages/npm/react@15.2.1/lib/ReactErrorUtils.js:26:11)
-  at executeDispatch(../jspm_packages/npm/react@15.2.1/lib/EventPluginUtils.js:89:4)
-  at EventPluginUtils(../jspm_packages/npm/react@15.2.1/lib/EventPluginUtils.js:112:4)
   at executeDispatchesAndRelease(../jspm_packages/npm/react@15.2.1/lib/EventPluginHub.js:44:4)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
@@ -192,24 +173,17 @@ describe('auto-trace.js', () => {
 			//IE and Edge docs - https://msdn.microsoft.com/en-us/library/windows/apps/hh699850.aspx
 			const err = new Error('err');
 			err.stack = `Error: message
-  at asyncStacktrace (../jspm_packages/npm/auto-trace@2.2.0/lib/auto-trace.js:46:2)
+  at asyncStacktrace (../jspm_packages/npm/trace@2.2.0/lib/trace.js:46:2)
   at updateAnswer (../src/source-forms/answers/answer.actions.js:60:4)
   at createThunkMiddleware (../jspm_packages/npm/redux-thunk@2.1.0/lib/index.js:11:10)
-  at func (../jspm_packages/npm/redux@3.5.2/lib/bindActionCreators.js:7:4)
-  at apply (../jspm_packages/npm/lodash@4.13.1/lodash.js:413:4)
-  at f (../jspm_packages/npm/lodash@4.13.1/lodash.js:4836:8)
   at fancyUpdateAnswer (../src/source-forms/questions/question.component.js:77:3)`;
     		const expectedStack = `Error: message
   at updateAnswer (../src/source-forms/answers/answer.actions.js:60:4)
   at createThunkMiddleware (../jspm_packages/npm/redux-thunk@2.1.0/lib/index.js:11:10)
-  at func (../jspm_packages/npm/redux@3.5.2/lib/bindActionCreators.js:7:4)
-  at apply (../jspm_packages/npm/lodash@4.13.1/lodash.js:413:4)
-  at f (../jspm_packages/npm/lodash@4.13.1/lodash.js:4836:8)
   at fancyUpdateAnswer (../src/source-forms/questions/question.component.js:77:3)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
-		it('should not remove the invoker call of catchAsyncStacktrace', () => {
-			//IE and Edge docs - https://msdn.microsoft.com/en-us/library/windows/apps/hh699850.aspx
+		it('should remove catchAsyncStacktrace in bundled files', () => {
 			const err = new Error('err');
 			err.stack = `Error: it broke
 	at catchAsyncStacktrace(/global-settings.js:1929:28)
@@ -218,21 +192,35 @@ describe('auto-trace.js', () => {
 	at dispatchEvent(../jspm_packages/npm/react-dom@15.5.4/lib/ReactErrorUtils.js:69:15)
 	at forEach(../jspm_packages/npm/react-dom@15.5.4/lib/forEachAccumulated.js:24:8)`;
 			const expectedStack = `Error: it broke
-	at catchAsyncStacktrace(/global-settings.js:1929:28)
 	at _showMoreLicensesDialog(/4.global-settings.js:428:111)
 	at HTMLUnknownElement.d(/static/raven/raven-3.9.1-d.min.js:2:6222)
 	at dispatchEvent(../jspm_packages/npm/react-dom@15.5.4/lib/ReactErrorUtils.js:69:15)
 	at forEach(../jspm_packages/npm/react-dom@15.5.4/lib/forEachAccumulated.js:24:8)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
-		it('should replace leave non-AutoTrace error stacks untouched', () => {
+		it('should remove catchAsyncStacktrace in minnified files', () => {
 			const err = new Error('err');
-			err.stack = `Error
-    at Object.<anonymous> (src/auto-trace.helper.spec.js:12:16)
-    at attemptSync (/Users/keith/dev/auto-trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
+			err.stack = `Error: it broke
+  at s(~/auto-trace/lib/auto-trace.js:46:0)
+  at ? (./src/source-forms/source-form-layout.actions.js:31:19)
+  at action(~/redux-thunk/lib/index.js:11:0)
+  at dispatch(./src/source-forms/source-form-for-tax-form.component.js:78:8)
+  at fetchSection(./src/source-forms/source-form-for-tax-form.component.js:122:8)`;
+			const expectedStack = `Error: it broke
+  at ? (./src/source-forms/source-form-layout.actions.js:31:19)
+  at action(~/redux-thunk/lib/index.js:11:0)
+  at dispatch(./src/source-forms/source-form-for-tax-form.component.js:78:8)
+  at fetchSection(./src/source-forms/source-form-for-tax-form.component.js:122:8)`;
+			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
+		});
+		it('should leave non-AutoTrace error stacks untouched', () => {
+			const err = new Error('err');
+			err.stack = `Error: err
+    at Object.<anonymous> (src/trace.helper.spec.js:12:16)
+    at attemptSync (/Users/keith/dev/trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
     		const expectedStack = `Error: err
-    at Object.<anonymous> (src/auto-trace.helper.spec.js:12:16)
-    at attemptSync (/Users/keith/dev/auto-trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
+    at Object.<anonymous> (src/trace.helper.spec.js:12:16)
+    at attemptSync (/Users/keith/dev/trace/node_modules/jasmine-core/lib/jasmine-core/jasmine.js:1886:24)`;
 			expect(removeAutoTraceFromErrorStack(err).stack).toEqual(expectedStack);
 		});
 		it('should not cause and error if err.stack is undefined', () => {

--- a/src/auto-trace.js
+++ b/src/auto-trace.js
@@ -1,4 +1,4 @@
-import { wrapObjectWithError } from './auto-trace.helper.js';
+import { wrapObjectWithError, createError } from './auto-trace.helper.js';
 let globalMiddlewares = [];
 
 /**
@@ -27,7 +27,7 @@ export function removeAllGlobalMiddlewares(){
  * @returns {Error}
  */
 export function asyncStacktrace(callback = ()=>{}, extraContext) {
-	const asyncStacktraceErr = new Error();
+	const asyncStacktraceErr = createError();
 	const syncMiddlewareErrFunctions = executeAsyncMiddleware(asyncStacktraceErr);
 
 	return (rawError) => {
@@ -48,12 +48,12 @@ export function asyncStacktrace(callback = ()=>{}, extraContext) {
  * @returns {Error}
  */
 export function catchAsyncStacktrace(extraContext) {
-	const asyncStacktraceErr = new Error();
+	const asyncStacktraceErr = createError();
 	const syncMiddlewareErrFunctions = executeAsyncMiddleware(asyncStacktraceErr);
 
 	return (rawError) => {
 		const middlewareErr = executeSyncMiddleware(syncMiddlewareErrFunctions, rawError);
-		const errOut = wrapObjectWithError(middlewareErr, asyncStacktraceErr, extraContext)
+		const errOut = wrapObjectWithError(middlewareErr, asyncStacktraceErr, extraContext);
 		setTimeout(() => {throw errOut});
 	};
 }
@@ -67,7 +67,7 @@ export function catchAsyncStacktrace(extraContext) {
  * @returns {Error}
  */
 export function syncStacktrace(rawError) {
-	const syncStacktraceErr = new Error();
+	const syncStacktraceErr = createError();
 	const syncMiddlewareErrFunctions = executeAsyncMiddleware(syncStacktraceErr);
 	const middlewareErr = executeSyncMiddleware(syncMiddlewareErrFunctions, rawError)
 	const syncErr = wrapObjectWithError(middlewareErr)
@@ -84,7 +84,7 @@ export function syncStacktrace(rawError) {
  * @throws {Error}
  */
 export function catchSyncStacktrace(rawError) {
-	const syncStacktraceErr = new Error();
+	const syncStacktraceErr = createError();
 	const syncMiddlewareErrFunctions = executeAsyncMiddleware(syncStacktraceErr);
 	const middlewareErr = executeSyncMiddleware(syncMiddlewareErrFunctions, rawError)
 	const syncErr = wrapObjectWithError(middlewareErr)


### PR DESCRIPTION
Auto-Trace wasn't correctly being removed from stack traces when running with minified code.

This PR puts an end to removing auto-trace from the stack via regex, and instead removes x number of frames from `err.stack` when an error is created by auto-trace. 

Additionally, `wrapObjectWithError` was not working as expected. It was storing the `async stacktrace` twice within `err.stack`. Now it stores the `async stack` followed by the `sync stack`.