### PR TITLE
IE stack.split('/n') fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -78,8 +78,8 @@ export function appendExtraContext(error, extraContext){
 //Optionally extraFramesToRemove can be specified to remove more frames if the stack trace will contain more auto-trace refrences.
 export function createError(extraFramesToRemove = 1){
 	const error = new Error();
-
-	//error.stack in IE is set to undefined when the error is first created
+debugger;
+	//error.stack in IE is undefined until the error is thrown
 	if (typeof error.stack === 'string'){
 		//We remove an extra frame since this function will create a frame as well
 		const newStack = error.stack.split('\n');

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -78,12 +78,16 @@ export function appendExtraContext(error, extraContext){
 //Optionally extraFramesToRemove can be specified to remove more frames if the stack trace will contain more auto-trace refrences.
 export function createError(extraFramesToRemove = 1){
 	const error = new Error();
-	//We remove an extra frame since this function will create a frame as well
-	const newStack = error.stack.split('\n');
-	if (newStack.length > extraFramesToRemove+1) {
-		//Starts on line 1 since the 0th line of the stacktrace is the error message (which we don't want to remove)
-		newStack.splice(1, extraFramesToRemove+1);
-		error.stack = newStack.join('\n');
+
+	//error.stack in IE is not a string
+	if (typeof error.stack === 'string'){
+		//We remove an extra frame since this function will create a frame as well
+		const newStack = error.stack.split('\n');
+		if (newStack.length > extraFramesToRemove+1) {
+			//Starts on line 1 since the 0th line of the stacktrace is the error message (which we don't want to remove)
+			newStack.splice(1, extraFramesToRemove+1);
+			error.stack = newStack.join('\n');
+		}
 	}
 	return error;
 }

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -79,7 +79,7 @@ export function appendExtraContext(error, extraContext){
 export function createError(extraFramesToRemove = 1){
 	const error = new Error();
 
-	//error.stack in IE is not a string
+	//error.stack in IE is set to undefined when the error is first created
 	if (typeof error.stack === 'string'){
 		//We remove an extra frame since this function will create a frame as well
 		const newStack = error.stack.split('\n');

--- a/src/auto-trace.helper.js
+++ b/src/auto-trace.helper.js
@@ -78,7 +78,7 @@ export function appendExtraContext(error, extraContext){
 //Optionally extraFramesToRemove can be specified to remove more frames if the stack trace will contain more auto-trace refrences.
 export function createError(extraFramesToRemove = 1){
 	const error = new Error();
-debugger;
+
 	//error.stack in IE is undefined until the error is thrown
 	if (typeof error.stack === 'string'){
 		//We remove an extra frame since this function will create a frame as well


### PR DESCRIPTION
In IE, `err.stack` is undefined until you throw, then the stack is set when the error is thrown

This checks to make sure that `err.stack` is of type `string` before modifying the stack