### PR TITLE
Add warning message for catchError and throw if error is passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-trace",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A library that fixes all your stack trace problems.",
   "main": "lib/auto-trace.js",
   "scripts": {

--- a/src/auto-trace.js
+++ b/src/auto-trace.js
@@ -16,6 +16,10 @@ let globalMiddlewares = [];
  *   }))
  */
 export function catchError(callback, extraContext) {
+  if (callback instanceof Error) {
+    console.warn('catchError must be called before being passed to an onError handler.\nFind any instance of `catchError` and replace with `catchError()`.\nAlso check that an error object is not being passed into catchError as the first parameter should be a function.\n We call catchError to wrap the error with additional information, so the following error might be missing some additional useful context.')
+    throw callback
+  }
   return asyncStacktrace((error) => {
     if (callback) {
       callback(error, function throwError(err) {


### PR DESCRIPTION
This is to warn about accidentally passing catchError as a error handler function instead of first calling `catchError()` as it generates the callback function to be used by an error handler.

e.g. when subscribing in rxjs
`fetchUsers().subscribe(onComplete, catchError)`
This would result in the error being swallowed. Now we send a warning message in the console and throw the error directly. 